### PR TITLE
Rework hard coded statement

### DIFF
--- a/paradox/generate/statements.py
+++ b/paradox/generate/statements.py
@@ -23,6 +23,7 @@ from paradox.interfaces import (
     AcceptsStatements,
     AlsoParam,
     DefinesCustomTypes,
+    ImplementationMissing,
     ImportSpecPHP,
     ImportSpecPy,
     ImportSpecTS,
@@ -330,28 +331,41 @@ class HardCodedStatement(StatementWithNoImports):
 
     def __init__(
         self,
-        python: str = None,
-        typescript: str = None,
-        php: str = None,
+        *,
+        python: "Union[str, None, builtins.ellipsis]" = ...,
+        typescript: "Union[str, None, builtins.ellipsis]" = ...,
+        php: "Union[str, None, builtins.ellipsis]" = ...,
     ) -> None:
         self._python = python
         self._typescript = typescript
         self._php = php
 
     def writets(self, w: FileWriter) -> None:
-        if self._typescript is None:
-            raise Exception("Not implemented in TS")
-        w.line0(self._typescript)
+        if self._typescript is ...:
+            raise ImplementationMissing(
+                "HardCodedStatement was not given a TypeScript implementation"
+            )
+        if self._typescript is not None:
+            # XXX: mypy doesn't realise that self._typescript cannot be ...
+            w.line0(self._typescript)  # type: ignore
 
     def writepy(self, w: FileWriter) -> None:
-        if self._python is None:
-            raise Exception("Not implemented in Python")
-        w.line0(self._python)
+        if self._python is ...:
+            raise ImplementationMissing(
+                "HardCodedStatement was not given a Python implementation"
+            )
+        if self._python is not None:
+            # XXX: mypy doesn't realise that self._python cannot be ...
+            w.line0(self._python)  # type: ignore
 
     def writephp(self, w: FileWriter) -> None:
-        if self._php is None:
-            raise Exception("Not implemented in PHP")
-        w.line0(self._php)
+        if self._php is ...:
+            raise ImplementationMissing(
+                "HardCodedStatement was not given a PHP implementation"
+            )
+        if self._php is not None:
+            # XXX: mypy doesn't realise that self._php cannot be ...
+            w.line0(self._php)  # type: ignore
 
 
 class RawTypescript(StatementWithNoImports):

--- a/paradox/generate/statements.py
+++ b/paradox/generate/statements.py
@@ -369,7 +369,7 @@ class HardCodedStatement(StatementWithNoImports):
 
 
 class RawTypescript(StatementWithNoImports):
-    """Used for simple statements that only need to work in Python."""
+    # TODO: deprecate this in favour of HardCodedStatement
 
     def __init__(self) -> None:
         super().__init__()

--- a/paradox/interfaces.py
+++ b/paradox/interfaces.py
@@ -37,6 +37,12 @@ class NotSupportedError(NotImplementedError):
     """When you attempt to use a feature that is not supported by the target language."""
 
 
+class ImplementationMissing(Exception):
+    """
+    Raised by hard-coded statement or expression when requested language implementation is missing.
+    """
+
+
 AlsoParam = TypeVar("AlsoParam", bound="Union[Statement, PanExpr]")
 
 

--- a/tests/test_generate_statements/test_HardCodedStatement.py
+++ b/tests/test_generate_statements/test_HardCodedStatement.py
@@ -1,0 +1,68 @@
+import builtins
+from typing import Dict, Union
+
+import pytest
+
+from _paradoxtest import SupportedLang
+from paradox.generate.statements import HardCodedStatement
+from paradox.interfaces import ImplementationMissing
+from paradox.output import Script
+
+
+# test a HardCodedStatement that has most languages, but not all
+def get_custom_statements() -> Dict[str, Union[str, None, "builtins.ellipsis"]]:
+    return {
+        "python": "print('hi there')",
+        "php": "echo 'hi there';",
+        "typescript": "console.log('hi there');",
+    }
+
+
+@pytest.mark.parametrize("send_ellipsis", [True, False])
+def test_HardCodedStatement(send_ellipsis: bool, LANG: SupportedLang) -> None:
+    # test a HardCodedStatement that has most languages, but not all
+    kwargs = get_custom_statements()
+
+    # remove implementation for one lang, either by sending the ellipsis or by
+    # omitting it from kwargs
+    if send_ellipsis:
+        kwargs[LANG] = ...
+    else:
+        kwargs.pop(LANG)
+
+    s = Script()
+
+    # test that we raise ImplementationMissing
+    s.also(HardCodedStatement())
+    with pytest.raises(
+        ImplementationMissing, match="HardCodedStatement was not given "
+    ):
+        s.get_source_code(lang=LANG)
+
+
+def test_HardCodedStatement_can_omit_each_lang(LANG: SupportedLang) -> None:
+    # test a HardCodedStatement that has most languages, but not all
+    stmts = get_custom_statements()
+
+    # set one lang to be omitted
+    stmts[LANG] = None
+
+    s = Script()
+
+    s.also(HardCodedStatement(**stmts))
+
+    expected_php = "<?php\n\necho 'hi there';\n"
+    expected_python = "print('hi there')\n"
+    expected_typescript = "console.log('hi there');\n"
+
+    if LANG == "php":
+        expected_php = "<?php\n\n"
+    elif LANG == "python":
+        expected_python = ""
+    else:
+        assert LANG == "typescript"
+        expected_typescript = ""
+
+    assert s.get_source_code(lang="php") == expected_php
+    assert s.get_source_code(lang="python") == expected_python
+    assert s.get_source_code(lang="typescript") == expected_typescript


### PR DESCRIPTION
* make langs kwarg-only
* make ellipsis (...) the default value that indicates an implementation is missing
* Use new ImplementationMissing exception for missing implementations
* allow setting <LANG>=None to leave an implementation blank without an error
* add some unit tests