### PR TITLE
Replace old addNewType() with new Script.add_new_type()

### DIFF
--- a/paradox/generate/statements.py
+++ b/paradox/generate/statements.py
@@ -33,7 +33,6 @@ from paradox.expressions import (
 from paradox.interfaces import (
     AcceptsStatements,
     AlsoParam,
-    DefinesCustomTypes,
     ImplementationMissing,
     ImportSpecPHP,
     ImportSpecPy,
@@ -72,30 +71,7 @@ def _pan_nodef(val: Union[Pannable, NoDefault]) -> Optional[PanExpr]:
     return pan(val)
 
 
-class Statement(WantsImports, DefinesCustomTypes, abc.ABC):
-    def __init__(self) -> None:
-        super().__init__()
-        self._newtypes: List[Tuple[str, CrossType, bool]] = []
-
-    def getTypesPy(self) -> Iterable[Tuple[str, CrossType]]:
-        """Yield tuples of <type name> <base type name>
-
-        ... where <base type name> would be something a str like 'int' or 'bool'.
-        """
-        for name, crossbase, export in self._newtypes:
-            yield name, crossbase
-
-    def getTypesTS(self) -> Iterable[Tuple[str, CrossType, bool]]:
-        """Yield tuples of <type name> <base type name> <want export>
-
-        ... where <base type name> would be a str like 'number' or 'boolean'.
-        """
-        for name, crossbase, export in self._newtypes:
-            yield name, crossbase, export
-
-    def addNewType(self, name: str, base: CrossType, *, export: bool = False) -> None:
-        self._newtypes.append((name, base, export))
-
+class Statement(WantsImports, abc.ABC):
     @abc.abstractmethod
     def writepy(self, w: FileWriter) -> int:
         ...

--- a/paradox/interfaces.py
+++ b/paradox/interfaces.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         Statement,
         TryCatchBlock,
     )
-    from paradox.typing import CrossType, FlexiType
+    from paradox.typing import FlexiType
 
 
 class NotSupportedError(NotImplementedError):
@@ -148,13 +148,3 @@ class WantsImports(abc.ABC):
         # XXX: we need to return an iterable here so that subclasses can use
         #   yield from super().getImportsPHP()
         return []
-
-
-class DefinesCustomTypes(abc.ABC):
-    @abc.abstractmethod
-    def getTypesPy(self) -> "Iterable[Tuple[str, CrossType]]":
-        ...
-
-    @abc.abstractmethod
-    def getTypesTS(self) -> "Iterable[Tuple[str, CrossType, bool]]":
-        ...

--- a/paradox/output/php.py
+++ b/paradox/output/php.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from paradox.interfaces import DefinesCustomTypes, WantsImports
-from paradox.output import FileWriter
+from paradox.interfaces import WantsImports
+from paradox.output import FileWriter, Script
 
 
 def write_file_comments(writer: FileWriter, comments: List[str]) -> None:
@@ -14,7 +14,7 @@ def write_file_comments(writer: FileWriter, comments: List[str]) -> None:
         writer.blank()
 
 
-def write_top_imports(writer: FileWriter, top: WantsImports) -> None:
+def write_top_imports(writer: FileWriter, *, top: WantsImports, script: Script) -> None:
     # group imports by source module so that we can sort them
     imports: Dict[str, Optional[str]] = {}
     for original, alias in top.getImportsPHP():
@@ -35,6 +35,6 @@ def write_top_imports(writer: FileWriter, top: WantsImports) -> None:
         writer.blank()
 
 
-def write_custom_types(writer: FileWriter, top: DefinesCustomTypes) -> None:
+def write_custom_types(writer: FileWriter, script: Script) -> None:
     # PHP doesn't support custom types
     pass

--- a/paradox/output/python.py
+++ b/paradox/output/python.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 from typing import Dict, List, Set
 
-from paradox.interfaces import DefinesCustomTypes, WantsImports
-from paradox.output import FileWriter
+from paradox.interfaces import WantsImports
+from paradox.output import FileWriter, Script
 
 
 def write_file_comments(writer: FileWriter, comments: List[str]) -> None:
@@ -12,7 +12,7 @@ def write_file_comments(writer: FileWriter, comments: List[str]) -> None:
     writer.line0('"""')
 
 
-def write_top_imports(writer: FileWriter, top: WantsImports) -> None:
+def write_top_imports(writer: FileWriter, *, top: WantsImports, script: Script) -> None:
     # group imports first
     direct_imports: Set[str] = set()
     named_imports: Dict[str, Set[str]] = defaultdict(set)
@@ -21,6 +21,14 @@ def write_top_imports(writer: FileWriter, top: WantsImports) -> None:
             direct_imports.add(module)
         else:
             named_imports[module].add(name)
+
+    for newtype in script._new_types.values():
+        named_imports["typing"].add("NewType")
+        for module, name in newtype.base.getPyImports():
+            if name is None:
+                direct_imports.add(module)
+            else:
+                named_imports[module].add(name)
 
     for name in sorted(direct_imports):
         writer.line0(f"import {name}")
@@ -33,6 +41,12 @@ def write_top_imports(writer: FileWriter, top: WantsImports) -> None:
         writer.blank()
 
 
-def write_custom_types(writer: FileWriter, top: DefinesCustomTypes) -> None:
-    for name, crossbase in top.getTypesPy():
-        raise NotImplementedError("TODO: implement this")
+def write_custom_types(writer: FileWriter, script: Script) -> None:
+    count = 0
+    for newtype in script._new_types.values():
+        pytype = newtype.base.getPyType()[0]
+        name = newtype.name
+        writer.line0(f"{name} = NewType({name!r}, {pytype})")
+        count += 1
+    if count:
+        writer.blank()

--- a/tests/test_output_Script.py
+++ b/tests/test_output_Script.py
@@ -16,8 +16,8 @@ def test_Script(LANG: SupportedLang) -> None:
     s = Script()
 
     # add some new types
-    s.add_new_type('UserEmail', maybe(str))
-    s.add_new_type('UserID', unflex(int), tsexport=True)
+    s.add_new_type("UserEmail", maybe(str))
+    s.add_new_type("UserID", unflex(int), tsexport=True)
 
     s.add_file_comment("Intro1")
     s.add_file_comment("Intro2")
@@ -100,6 +100,6 @@ def test_Script(LANG: SupportedLang) -> None:
 def test_cannot_add_same_new_type_twice() -> None:
     s = Script()
 
-    s.add_new_type('some_type', unflex(str))
+    s.add_new_type("some_type", unflex(str))
     with pytest.raises(InvalidLogic):
-        s.add_new_type('some_type', unflex(str))
+        s.add_new_type("some_type", unflex(str))


### PR DESCRIPTION
* the export kwarg is renamed tsexport since that feature is only supported by TS
* remove apparatus for attaching new types to Statements
* remove the DefinesCustomTypes interface
* refactor the write_top_imports() and write_custom_types() helpers